### PR TITLE
Fix twitter link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@ Comunidades Vue.js ao redor do Brasil
 - [Facebook (página)](https://www.facebook.com/vuejsbrasil/)
 - [Telegram](https://t.me/vuejsbrasil)
 - [Telegram (Quasar)](https://t.me/quasarframeworkbrasil)
-- [Twitter](https://t.me/quasarframeworkbrasil)
+- [Twitter](https://twitter.com/vuejs_brasil)
 - [G+](https://plus.google.com/communities/104012886918830494146)
 
 # Regionais
 ## Meetup
 
-Cidade | Link | 
+Cidade | Link |
 ------ | ----
-São Paulo | [Meetup](https://www.meetup.com/pt-BR/VueJS-SP/) 
-Rio de Janeiro | [Meetup](https://www.meetup.com/pt-BR/Vue-js-in-Rio) 
-Belo Horizonte | [Meetup](https://www.meetup.com/pt-BR/Vuejs-at-BH) 
-Porto Alegre | [Meetup](https://www.meetup.com/pt-BR/Meetup-de-Vue-js-Porto-Alegre) 
+São Paulo | [Meetup](https://www.meetup.com/pt-BR/VueJS-SP/)
+Rio de Janeiro | [Meetup](https://www.meetup.com/pt-BR/Vue-js-in-Rio)
+Belo Horizonte | [Meetup](https://www.meetup.com/pt-BR/Vuejs-at-BH)
+Porto Alegre | [Meetup](https://www.meetup.com/pt-BR/Meetup-de-Vue-js-Porto-Alegre)
 Florianópolis | [Meetup](https://www.meetup.com/pt-BR/floripa-vuejs/), [Github](https://github.com/vuefloripa), [Slack](https://join.slack.com/t/vuefloripa/shared_invite/enQtMjQyNjYwNDEyMTk4LTY1ZDVmMTg2ZmZiNzM4Mjk3YjhhNjlmYWQ4ZDM0NzliMTcwZTk4NjFhMjliZGIxYmE5YzU0M2ViMTc4NGY3MzE), [Youtube](https://www.youtube.com/channel/UCzQX1I0wiW64Fh7dVUIM-BA)


### PR DESCRIPTION
O link do Twitter estava direcionando para o grupo do Quasar no telegram.