### PR TITLE
Add vuejs-norte

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,5 +29,4 @@ Florianópolis | [Meetup](https://www.meetup.com/pt-BR/floripa-vuejs/), [Github]
 Porto Alegre | [Meetup](https://www.meetup.com/pt-BR/Meetup-de-Vue-js-Porto-Alegre)
 Rio de Janeiro | [Meetup](https://www.meetup.com/pt-BR/Vue-js-in-Rio)
 São Paulo | [Meetup](https://www.meetup.com/pt-BR/VueJS-SP/)
-
-
+Belém | [Meetup](https://www.meetup.com/Vue-js-Norte/), [GitHub](https://github.com/vuejs-norte)


### PR DESCRIPTION
Comunidade de desenvolvedores Vue.js do Norte do Brasil, originalmente criado em Belém/PA.